### PR TITLE
Fix s:SetAutoCmd bug

### DIFF
--- a/plugin/haml-compile.vim
+++ b/plugin/haml-compile.vim
@@ -33,7 +33,6 @@ function! s:SetAutoCmd(files)
         endfor
     endif
     unlet file
-    unlet s:SetAutoCmd
 endfunction
 au VimEnter * call s:SetAutoCmd(g:haml_compile_file)
 


### PR DESCRIPTION
When I use this plugin, the following error occurred.

```
function <SNR>72_SetAutoCmd の処理中にエラーが検出されました:
行   13:
E108: その変数はありません: "s:SetAutoCmd"
```

This pull request fix this.
